### PR TITLE
Migrate setup_jitsi_auth_uvs_uninstall.yml to loops

### DIFF
--- a/tasks/util/setup_jitsi_auth_uvs_uninstall.yml
+++ b/tasks/util/setup_jitsi_auth_uvs_uninstall.yml
@@ -4,9 +4,9 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: absent
-  with_flattened:
-    - "{{ jitsi_prosody_auth_matrix_user_verification_repo_target }}"
-    - "{{ jitsi_prosody_auth_matrix_files | map(attribute='path') | map('regex_replace', '^', jitsi_prosody_plugins_path+'/') | list }}"
+  loop:
+    - "{{ jitsi_prosody_auth_matrix_user_verification_repo_target | flatten  }}"
+    - "{{ jitsi_prosody_auth_matrix_files | map(attribute='path') | map('regex_replace', '^', jitsi_prosody_plugins_path+'/') | list | flatten }}"
   register: jitsi_prosody_auth_matrix_user_verification_uninstalled
 
 - when: jitsi_prosody_auth_matrix_user_verification_uninstalled.changed


### PR DESCRIPTION
Looks like you're supposed to use loops and filters now according to https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_loops.html#with-flattened